### PR TITLE
GH-18 - Improve hashtag help text

### DIFF
--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -117,13 +117,13 @@ export default class MeetingSettingsModal extends React.PureComponent {
                             className='form-control'
                             value={this.state.hashtag ? this.state.hashtag : ''}
                         />
-                        <p className='text-muted pt-1'> {'Hashtag is formatted using the '}	
-                            <a	
-                                target='_blank'	
-                                rel='noopener noreferrer'	
-                                href='https://godoc.org/time#pkg-constants'	
-                            >{'Go time package.'}</a>	
-                            {' Embed a date by writing down what January 2, 2006 would look like.'}	
+                        <p className='text-muted pt-1'> {'Hashtag is formatted using the '}
+                            <a
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                href='https://godoc.org/time#pkg-constants'
+                            >{'Go time package.'}</a>
+                            {' Embed a date by writing down what January 2, 2006 would look like.'}
                         </p>
                     </div>
                 </Modal.Body>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -117,13 +117,13 @@ export default class MeetingSettingsModal extends React.PureComponent {
                             className='form-control'
                             value={this.state.hashtag ? this.state.hashtag : ''}
                         />
-                        <p className='text-muted pt-1'> {'Date format must follow  '}
-                            <a
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href='https://yourbasic.org/golang/format-parse-string-time-date-example/#standard-time-and-date-formats'
-                            >{'the predefined layouts'}</a>
-                            {' using January 02, 2006 as the reference date.'}
+                        <p className='text-muted pt-1'> {'Hashtag is formatted using the '}	
+                            <a	
+                                target='_blank'	
+                                rel='noopener noreferrer'	
+                                href='https://godoc.org/time#pkg-constants'	
+                            >{'Go time package.'}</a>	
+                            {' Embed a date by writing down what January 2, 2006 would look like.'}	
                         </p>
                     </div>
                 </Modal.Body>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -117,12 +117,13 @@ export default class MeetingSettingsModal extends React.PureComponent {
                             className='form-control'
                             value={this.state.hashtag ? this.state.hashtag : ''}
                         />
-                        <p className='text-muted pt-1'> {'Date format should follow the one of  '}
+                        <p className='text-muted pt-1'> {'Date format must follow  '}
                             <a
                                 target='_blank'
                                 rel='noopener noreferrer'
                                 href='https://yourbasic.org/golang/format-parse-string-time-date-example/#standard-time-and-date-formats'
                             >{'the predefined layouts'}</a>
+                            {' using January 02, 2006 as the reference date.'}
                         </p>
                     </div>
                 </Modal.Body>


### PR DESCRIPTION
#### Summary
Specified reference date that must be included in the date format for the meeting hashtag. Follow up from PR https://github.com/mattermost/mattermost-plugin-agenda/pull/2

#### Screenshot

<img width="809" alt="Screen Shot 2020-03-16 at 9 25 46 AM" src="https://user-images.githubusercontent.com/936315/76977884-52ecdc00-690c-11ea-919d-4b48e2d7109c.png">

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-agenda/issues/18

