### PR TITLE
initialize default redux state from reducer

### DIFF
--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -8,6 +8,7 @@ import ChannelSettingsModal from './components/meeting_settings';
 import {id as pluginId} from './manifest';
 export default class Plugin {
     initialize(registry, store) {
+        registry.registerReducer(reducer);
         registry.registerWebSocketEventHandler(
             'custom_' + pluginId + '_list',
             handleSearchHashtag(store),
@@ -18,8 +19,6 @@ export default class Plugin {
             (channelId) => {
                 store.dispatch(openMeetingSettingsModal(channelId));
             });
-
-        registry.registerReducer(reducer);
     }
 }
 

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -1,8 +1,6 @@
 import {id as pluginId} from './manifest';
-import reducer from './reducer';
 
-const defaultState = reducer({}, {});
-const getPluginState = (state) => state['plugins-' + pluginId] || defaultState;
+const getPluginState = (state) => state['plugins-' + pluginId] || {};
 
 export const getMeetingSettingsModalState = (state) => getPluginState(state).meetingSettingsModal;
 export const getMeetingSettings = (state) => getPluginState(state).meetingSettings;

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -1,6 +1,8 @@
 import {id as pluginId} from './manifest';
+import reducer from './reducer';
 
-const getPluginState = (state) => state['plugins-' + pluginId] || {};
+const defaultState = reducer({}, {});
+const getPluginState = (state) => state['plugins-' + pluginId] || defaultState;
 
 export const getMeetingSettingsModalState = (state) => getPluginState(state).meetingSettingsModal;
 export const getMeetingSettings = (state) => getPluginState(state).meetingSettings;


### PR DESCRIPTION
#### Summary
The selectors assume a fully populated initial state, and currently result in resolving a property on an undefined object. By falling back to the default state from the reducer (before Redux itself kicks in), we
avoid this race condition and allow normal usage of the selectors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23553