### PR TITLE
Fix user input being used as format string in various command handlers

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -66,7 +66,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 	}
 
-	return responsef("Unknown action: " + action), nil
+	return responsef("Unknown action: %s", action), nil
 }
 
 func (p *Plugin) executeCommandList(args *model.CommandArgs) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -122,7 +122,7 @@ func (p *Plugin) executeCommandSetting(args *model.CommandArgs) *model.CommandRe
 		//set hashtag
 		meeting.HashtagFormat = value
 	default:
-		return responsef("Unknow setting " + field)
+		return responsef("Unknown setting %s", field)
 	}
 
 	if err := p.SaveMeeting(meeting); err != nil {

--- a/server/command.go
+++ b/server/command.go
@@ -164,7 +164,7 @@ func (p *Plugin) executeCommandQueue(args *model.CommandArgs) *model.CommandResp
 		Message:   fmt.Sprintf("#### %v %v) %v", hashtag, len(itemsQueued)+1, message),
 	})
 	if appErr != nil {
-		return responsef("Error creating post: " + appErr.Message)
+		return responsef("Error creating post: %s", appErr.Message)
 	}
 
 	return &model.CommandResponse{}


### PR DESCRIPTION
#### Summary
Fix user input being used as format string in various command handlers

For example "/agenda setting %s foo" resulted in "Unknow setting %!s(MISSING)"

#### Ticket Link
Don't have one