### PR TITLE
feat: allow weekday short names for schedule configuration

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
-	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -111,12 +108,11 @@ func (p *Plugin) executeCommandSetting(args *model.CommandArgs) *model.CommandRe
 	switch field {
 	case "schedule":
 		//set schedule
-		weekdayInt, err := strconv.Atoi(value)
-		validWeekday := weekdayInt >= 0 && weekdayInt <= 6
-		if err != nil || !validWeekday {
-			return responsef("Invalid weekday. Must be between 1-5")
+		weekDayInt, err := parseSchedule(value)
+		if err != nil {
+			return responsef(err.Error())
 		}
-		meeting.Schedule = time.Weekday(weekdayInt)
+		meeting.Schedule = weekDayInt
 
 	case "hashtag":
 		//set hashtag

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,8 +1,53 @@
 package main
 
 import (
+	"errors"
+	"strconv"
+	"strings"
 	"time"
 )
+
+const (
+	scheduleErrorInvalid       = "Invalid weekday. Must be between 1-5 or Mon-Fri"
+	scheduleErrorInvalidNumber = "Invalid weekday. Must be between 1-5"
+)
+
+var daysOfWeek = map[string]time.Weekday{}
+
+func init() {
+	for d := time.Sunday; d <= time.Saturday; d++ {
+		name := strings.ToLower(d.String())
+		daysOfWeek[name] = d
+		daysOfWeek[name[:3]] = d
+	}
+}
+
+// parseSchedule will return a given Weekday based on the string being either a number,
+// short / full name day of week.
+func parseSchedule(val string) (time.Weekday, error) {
+	if len(val) < 3 {
+		return parseScheduleNumber(val)
+	}
+	if weekDayName, ok := daysOfWeek[strings.ToLower(val)]; ok {
+		return weekDayName, nil
+	}
+	// try parsing number again in case prefixed by zeros
+	weekDayInt, err := parseScheduleNumber(val)
+	if err != nil {
+		return -1, errors.New(scheduleErrorInvalid)
+	}
+	return weekDayInt, nil
+}
+
+// parseScheduleNumber will return a given Weekday based on the corresponding int val.
+func parseScheduleNumber(val string) (time.Weekday, error) {
+	weekdayInt, err := strconv.Atoi(val)
+	validWeekday := weekdayInt >= 0 && weekdayInt <= 6
+	if err != nil || !validWeekday {
+		return -1, errors.New(scheduleErrorInvalidNumber)
+	}
+	return time.Weekday(weekdayInt), nil
+}
 
 // nextWeekdayDate calculates the date of the next given weekday
 // based on today's date.

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_parseSchedule(t *testing.T) {
+	type args struct {
+		val string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Weekday
+		wantErr bool
+	}{
+		{name: "test number", args: args{val: "0"}, want: 0, wantErr: false},
+		{name: "test number", args: args{val: "14"}, want: -1, wantErr: true},
+		{name: "test short name", args: args{val: "Mon"}, want: 1, wantErr: false},
+		{name: "test short name lower case", args: args{val: "sat"}, want: 6, wantErr: false},
+		{name: "test short name upper case", args: args{val: "FRI"}, want: 5, wantErr: false},
+		{name: "test full name", args: args{val: "Monday"}, want: 1, wantErr: false},
+		{name: "test full name lower case", args: args{val: "saturday"}, want: 6, wantErr: false},
+		{name: "test full name upper case", args: args{val: "FRIDAY"}, want: 5, wantErr: false},
+		{name: "test unknown val", args: args{val: "SOMEDAY"}, want: -1, wantErr: true},
+		{name: "test number left-padded (one zero)", args: args{val: "01"}, want: 1, wantErr: false},
+		{name: "test number left-padded (three zeros)", args: args{val: "0001"}, want: 1, wantErr: false},
+		{name: "test invalid number left-padded (three zeros)", args: args{val: "0014"}, want: -1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSchedule(tt.args.val)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSchedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseSchedule() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Closes #11 
This task is to extend support to include a shorthand string for the weekdays besides integers like: Mon or Tue.
In addition, full name of weekdays are also valid inputs.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA: https://mattermost.atlassian.net/browse/MM-22738
