### PR TITLE
GH-21 - include CSRF token in API requests

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3648,11 +3648,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -4729,11 +4724,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -4913,11 +4903,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -8308,11 +8293,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -8343,11 +8323,6 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
-    },
-    "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -9972,7 +9947,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -10627,6 +10603,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -10671,74 +10648,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
-    },
-    "superagent": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.2.2.tgz",
-      "integrity": "sha512-pMWBUnIllK4ZTw7p/UaobiQPwAO5w/1NRRTDpV0FTVNmECztsxKspj3ZWEordVEaqpZtmOQJJna4yTLyC/q7PQ==",
-      "requires": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.1",
-        "methods": "^1.1.2",
-        "mime": "^2.4.4",
-        "qs": "^6.9.1",
-        "readable-stream": "^3.4.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "qs": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -11299,7 +11208,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -55,7 +55,6 @@
     "react-redux": "7.2.0",
     "redux": "4.0.5",
     "selectors": "0.0.1",
-    "superagent": "5.2.2",
     "typescript": "3.8.3"
   }
 }

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -1,4 +1,3 @@
-import request from 'superagent';
 import {Client4} from 'mattermost-redux/client';
 
 import {id as pluginId} from './manifest';
@@ -16,30 +15,35 @@ export default class Client {
         return this.doPost(`${this.url}/settings`, meeting);
     }
 
-    doGet = async (url, body, headers = {}) => {
-        const response = await request.
-            get(url).
-            set({...this.getCommonHeaders(), ...headers}).
-            accept('application/json');
-
-        return response.body;
+    doGet = async (url, headers = {}) => {
+        return this.doFetch(url, { headers });
     }
 
     doPost = async (url, body, headers = {}) => {
-        const response = await request.
-            post(url).
-            send(body).
-            set({...this.getCommonHeaders(), ...headers}).
-            type('application/json').
-            accept('application/json');
+        return this.doFetch(url, {
+            method : 'POST',
+            body: JSON.stringify(body),
+            headers: {...headers, ...{
+                'Content-Type' : 'application/json'
+            }}
+        });
+    }
 
-        return response.body;
+    doFetch = async (url, { method = 'GET', body = null, headers = {} }) => {
+        const response = await fetch(url, {
+            method,
+            body,
+            headers: {...this.getCommonHeaders(), ...headers}
+        });
+
+        return response.json();
     }
 
     getCommonHeaders = () => {
         const { headers } = Client4.getOptions([]);
 
         headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
+        headers['Accept'] = 'application/json';
 
         return headers;
     }

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -22,22 +22,22 @@ export default class Client {
 
     doPost = async (url, body, headers = {}) => {
         return this.doFetch(url, {
-            method : 'POST',
+            method: 'POST',
             body: JSON.stringify(body),
             headers: {
-                ...headers, 
-                'Content-Type' : 'application/json',
-            }
+                ...headers,
+                'Content-Type': 'application/json',
+            },
         });
     }
 
-    doFetch = async (url, { method = 'GET', body = null, headers = {} }) => {
+    doFetch = async (url, {method = 'GET', body = null, headers = {}}) => {
         const options = Client4.getOptions({
             method,
             body,
             headers: {
                 ...headers,
-                'Accept' : 'application/json'
+                Accept: 'application/json',
             },
         });
 
@@ -55,5 +55,4 @@ export default class Client {
             url,
         });
     }
-
 }

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -1,4 +1,5 @@
 import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 import {id as pluginId} from './manifest';
 
@@ -43,7 +44,17 @@ export default class Client {
 
         const response = await fetch(url, options);
 
-        return response.json();
+        if (response.ok) {
+            return response.json();
+        }
+
+        const data = await response.text();
+
+        throw new ClientError(Client4.url, {
+            message: data || '',
+            status_code: response.status,
+            url,
+        });
     }
 
 }

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -37,7 +37,6 @@ export default class Client {
             body,
             headers: {
                 ...headers,
-                'X-Timezoone-Offset' : new Date().getTimezoneOffset(),
                 'Accept' : 'application/json'
             },
         });

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -1,4 +1,5 @@
 import request from 'superagent';
+import {Client4} from 'mattermost-redux/client';
 
 import {id as pluginId} from './manifest';
 
@@ -16,28 +17,30 @@ export default class Client {
     }
 
     doGet = async (url, body, headers = {}) => {
-        headers['X-Requested-With'] = 'XMLHttpRequest';
-        headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
-
         const response = await request.
             get(url).
-            set(headers).
+            set({...this.getCommonHeaders(), ...headers}).
             accept('application/json');
 
         return response.body;
     }
 
     doPost = async (url, body, headers = {}) => {
-        headers['X-Requested-With'] = 'XMLHttpRequest';
-        headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
-
         const response = await request.
             post(url).
             send(body).
-            set(headers).
+            set({...this.getCommonHeaders(), ...headers}).
             type('application/json').
             accept('application/json');
 
         return response.body;
+    }
+
+    getCommonHeaders = () => {
+        const { headers } = Client4.getOptions([]);
+
+        headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
+
+        return headers;
     }
 }

--- a/webapp/src/client.js
+++ b/webapp/src/client.js
@@ -16,35 +16,34 @@ export default class Client {
     }
 
     doGet = async (url, headers = {}) => {
-        return this.doFetch(url, { headers });
+        return this.doFetch(url, {headers});
     }
 
     doPost = async (url, body, headers = {}) => {
         return this.doFetch(url, {
             method : 'POST',
             body: JSON.stringify(body),
-            headers: {...headers, ...{
-                'Content-Type' : 'application/json'
-            }}
+            headers: {
+                ...headers, 
+                'Content-Type' : 'application/json',
+            }
         });
     }
 
     doFetch = async (url, { method = 'GET', body = null, headers = {} }) => {
-        const response = await fetch(url, {
+        const options = Client4.getOptions({
             method,
             body,
-            headers: {...this.getCommonHeaders(), ...headers}
+            headers: {
+                ...headers,
+                'X-Timezoone-Offset' : new Date().getTimezoneOffset(),
+                'Accept' : 'application/json'
+            },
         });
+
+        const response = await fetch(url, options);
 
         return response.json();
     }
 
-    getCommonHeaders = () => {
-        const { headers } = Client4.getOptions([]);
-
-        headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
-        headers['Accept'] = 'application/json';
-
-        return headers;
-    }
 }


### PR DESCRIPTION
**Summary**
Includes CSRF token in all API requests by utilizing the `getOptions` function exposed by the mattermost-redux library.

**Important Note**: I couldn't actually see the CSRF token in the result of calling `getOptions`, while testing my branch, but it definitely should be adding it, if it's on the cookie.

![Screenshot from 2020-04-22 06-34-03](https://user-images.githubusercontent.com/24561400/79941041-a9958a80-8463-11ea-92d8-e9e006b34514.png)

**Ticket**
Closes [#21](https://github.com/mattermost/mattermost-plugin-agenda/issues/21)