### PR TITLE
Fix panic if channel is meeting is not found

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -141,6 +141,8 @@ func (p *Plugin) httpMeetingDaysAutocomplete(w http.ResponseWriter, r *http.Requ
 	meeting, err := p.GetMeeting(query.Get("channel_id"))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error getting meeting days: %s", err.Error()), http.StatusInternalServerError)
+		p.API.LogDebug("Failed to find meeting for autocomplete", "error", err.Error(), "listCommand", listCommand)
+		return
 	}
 
 	ret := make([]model.AutocompleteListItem, 0)


### PR DESCRIPTION
#### Summary
Fix a `panic` if the meeting for autocomplete and add a log message.

#### Ticket Link
https://community-daily.mattermost.com/core/pl/g5c8dwh5ufrtpprtontzeecnuc

