### PR TITLE
Fixed failed prop-type error in console  when opening agendas modal

### DIFF
--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -17,7 +17,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
         super(props);
 
         this.state = {
-            hashtag: 'Jan02',
+            hashtag: '{{Jan02}}',
             weekdays: [1],
         };
     }
@@ -122,7 +122,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
                         <input
                             onInput={this.handleHashtagChange}
                             className='form-control'
-                            value={this.state.hashtag ? this.state.hashtag : ''}
+                            placeholder={this.state.hashtag ? this.state.hashtag : ''}
+                            defaultValue={this.state.hashtag ? this.state.hashtag : ''}
                         />
                         <p className='text-muted pt-1'> {'Hashtag is formatted using the '}
                             <a

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -120,10 +120,9 @@ export default class MeetingSettingsModal extends React.PureComponent {
                     <div className='form-group'>
                         <label className='control-label'>{'Hashtag Format'}</label>
                         <input
-                            onInput={this.handleHashtagChange}
+                            onChange={this.handleHashtagChange}
                             className='form-control'
-                            placeholder={this.state.hashtag ? this.state.hashtag : ''}
-                            defaultValue={this.state.hashtag ? this.state.hashtag : ''}
+                            value={this.state.hashtag ? this.state.hashtag : ''}
                         />
                         <p className='text-muted pt-1'> {'Hashtag is formatted using the '}
                             <a

--- a/webapp/src/reducer.js
+++ b/webapp/src/reducer.js
@@ -2,7 +2,7 @@ import {combineReducers} from 'redux';
 
 import ActionTypes from './action_types';
 
-const meetingSettingsModal = (state = false, action) => {
+const meetingSettingsModal = (state = {visible: false, channelId: ''}, action) => {
     switch (action.type) {
     case ActionTypes.OPEN_MEETING_SETTINGS_MODAL:
         return {


### PR DESCRIPTION
#### Summary

Failed prop-type error appears in console when agenda's popup is opened.

![image](https://user-images.githubusercontent.com/22114682/95676012-c8860580-0bd8-11eb-94f9-5eac7d4620b0.png)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-agenda/issues/61
