### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,10 @@
     "id": "com.mattermost.agenda",
     "name": "Agenda",
     "description": "Plugin to handle meeting agendas for Mattermost channels.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-agenda",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-agenda/issues",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-agenda/releases/tag/v0.2.1",
+    "icon_path": "",
     "version": "0.2.1",
     "min_server_version": "5.26.0",
     "server": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -15,6 +15,9 @@ const manifestStr = `
   "id": "com.mattermost.agenda",
   "name": "Agenda",
   "description": "Plugin to handle meeting agendas for Mattermost channels.",
+  "homepage_url": "https://github.com/mattermost/mattermost-plugin-agenda",
+  "support_url": "https://github.com/mattermost/mattermost-plugin-agenda/issues",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-agenda/releases/tag/v0.2.1",
   "version": "0.2.1",
   "min_server_version": "5.26.0",
   "server": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -5,6 +5,9 @@ const manifest = JSON.parse(`
     "id": "com.mattermost.agenda",
     "name": "Agenda",
     "description": "Plugin to handle meeting agendas for Mattermost channels.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-agenda",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-agenda/issues",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-agenda/releases/tag/v0.2.1",
     "version": "0.2.1",
     "min_server_version": "5.26.0",
     "server": {


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
Part of https://github.com/mattermost/mattermost-plugin-agenda/issues/69