### PR TITLE
[GH-66] Improve date format selection UI. Fixes #66

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-                                 Apache License
+                                 Apache License 
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-                                 Apache License 
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -16,7 +16,7 @@ var (
 type Meeting struct {
 	ChannelID     string         `json:"channelId"`
 	Schedule      []time.Weekday `json:"schedule"`
-	HashtagFormat string         `json:"hashtagFormat"` // Default: {ChannelName}-Jan02
+	HashtagFormat string         `json:"hashtagFormat"` // Default: {ChannelName}-Jan-2
 }
 
 // GetMeeting returns a meeting
@@ -37,9 +37,10 @@ func (p *Plugin) GetMeeting(channelID string) (*Meeting, error) {
 		if err != nil {
 			return nil, err
 		}
+		paddedChannelName := strings.ReplaceAll(channel.Name, "-", "_")
 		meeting = &Meeting{
 			Schedule:      []time.Weekday{time.Thursday},
-			HashtagFormat: strings.Join([]string{fmt.Sprintf("%.15s", channel.Name), "{{ Jan02 }}"}, "-"),
+			HashtagFormat: strings.Join([]string{fmt.Sprintf("%.15s", paddedChannelName), "{{ Jan 2 }}"}, "_"),
 			ChannelID:     channelID,
 		}
 	}
@@ -92,8 +93,10 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int) (
 		prefix = matchGroups[1]
 		hashtagFormat = strings.TrimSpace(matchGroups[2])
 		postfix = matchGroups[3]
+		formattedDate := meetingDate.Format(hashtagFormat)
+		formattedDate = strings.ReplaceAll(formattedDate, " ", "_")
 
-		hashtag = fmt.Sprintf("#%s%v%s", prefix, meetingDate.Format(hashtagFormat), postfix)
+		hashtag = fmt.Sprintf("#%s%v%s", prefix, formattedDate, postfix)
 	} else {
 		hashtag = fmt.Sprintf("#%s", meeting.HashtagFormat)
 	}

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -55,9 +55,9 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 				meeting: &Meeting{
 					ChannelID:     "QA",
 					Schedule:      []time.Weekday{time.Wednesday},
-					HashtagFormat: "{{Jan02}}",
+					HashtagFormat: "{{Jan 2}}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Wednesday, true).Format("Jan02"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Wednesday, true).Format("Jan 2"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -67,9 +67,9 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 				meeting: &Meeting{
 					ChannelID:     "QA Backend",
 					Schedule:      []time.Weekday{time.Monday},
-					HashtagFormat: "QA-{{January 02 2006}}",
+					HashtagFormat: "QA_{{January 02 2006}}",
 				}},
-			want:    "#QA-" + assertNextWeekdayDate(time.Monday, true).Format("January 02 2006"),
+			want:    "#QA_" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, true).Format("January 02 2006"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -81,7 +81,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "{{January 02 2006}}.vue",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + ".vue",
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + ".vue",
 			wantErr: false,
 		},
 		{
@@ -93,7 +93,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "React {{January 02 2006}} Born",
 				}},
-			want:    "#React " + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + " Born",
+			want:    "#React " + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + " Born",
 			wantErr: false,
 		},
 		{
@@ -105,7 +105,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "January 02 2006 {{January 02 2006}} January 02 2006",
 				}},
-			want:    "#January 02 2006 " + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + " January 02 2006",
+			want:    "#January 02 2006 " + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + " January 02 2006",
 			wantErr: false,
 		},
 		{
@@ -117,7 +117,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:  []time.Weekday{time.Monday},
 					HashtagFormat: "{{   January 02 2006			}}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -129,7 +129,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "{{ Mon Jan _2 }}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("Mon Jan _2"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("Mon Jan _2"), " ", "_"),
 			wantErr: false,
 		},
 	}
@@ -176,7 +176,7 @@ func TestPlugin_GetMeeting(t *testing.T) {
 			},
 			want: &Meeting{
 				Schedule:      []time.Weekday{time.Thursday},
-				HashtagFormat: "Short-{{ Jan02 }}",
+				HashtagFormat: "Short_{{ Jan 2 }}",
 				ChannelID:     "#short.name.channel",
 			},
 			wantErr: false,
@@ -190,7 +190,7 @@ func TestPlugin_GetMeeting(t *testing.T) {
 			},
 			want: &Meeting{
 				Schedule:      []time.Weekday{time.Thursday},
-				HashtagFormat: "Very Long Chann-{{ Jan02 }}",
+				HashtagFormat: "Very Long Chann_{{ Jan 2 }}",
 				ChannelID:     "#long.name.channel",
 			},
 			wantErr: false,

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -213,7 +213,6 @@ export default class MeetingSettingsModal extends React.PureComponent {
                                 style={{padding: '5px', minWidth: '175px'}}
                             >
                                 <label className='control-label'>{'Date Format'}</label>
-                                <br/>
                                 <Select
                                     name='format'
                                     className='form-select'

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -24,10 +24,39 @@ export default class MeetingSettingsModal extends React.PureComponent {
     ];
 
     customStyles = {
+        menu: (provided) => {
+            return {
+                ...provided,
+                background: 'var(--center-channel-bg)',
+                color: 'var(--center-channel-color)',
+            };
+        },
+        option: (provided, { isFocused, isDisabled, isSelected }) => {
+            const bgColor = isFocused
+                ? {
+                      backgroundColor: 'var(--button-bg)',
+                      color: 'var(--button-color)',
+                  }
+                : {};
+
+            return {
+                ...provided,
+                ...bgColor,
+                ':active': {
+                    ...provided[':active'],
+                    backgroundColor: !isDisabled
+                        ? isSelected
+                            ? 'var(--button-bg)'
+                            : 'var(--center-channel-bg)'
+                        : undefined,
+                },
+            };
+        },
         menuList: (provided) => {
             return ({
                 ...provided,
                 height: 188,
+                color: 'var(--center-channel-color)',
             });
         },
         control: (provided, state) => ({
@@ -39,6 +68,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
             '&:hover': {
                 border: '1px solid #ced4da',
             },
+            background: 'var(--center-channel-bg)',
         }),
         indicatorsContainer: (provided) => {
             return ({
@@ -49,8 +79,9 @@ export default class MeetingSettingsModal extends React.PureComponent {
         singleValue: (provided, state) => {
             const opacity = state.isDisabled ? 0.5 : 1;
             const transition = 'opacity 300ms';
-
-            return {...provided, opacity, transition};
+            const color = 'var(--center-channel-color)';
+            const background = 'var(--center-channel-bg)';
+            return { ...provided, opacity, transition, color, background };
         },
     }
 

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -29,7 +29,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
                 color: 'var(--center-channel-color)',
             };
         },
-        option: (provided, {isFocused, isDisabled, isSelected}) => {
+        option: (provided, {isFocused, isSelected}) => {
             const bgColor = isFocused ?
                 {
                     backgroundColor: 'var(--button-bg)',
@@ -43,8 +43,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
                 ':active': {
                     ...provided[':active'],
                     backgroundColor: isSelected ?
-                    'var(--button-bg)' :
-                    'var(--center-channel-bg)',
+                        'var(--button-bg)' :
+                        'var(--center-channel-bg)',
                 },
             };
         },

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -154,8 +154,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
                                     style={{height: '35px', border: '1px solid #ced4da'}}
                                     className='form-select'
                                 >
-                                    <option value='Jan 2'>{'Month_day'}</option>
-                                    <option value='2 Jan'>{'day_Month'}</option>
+                                    <option value='Jan 2'>{'month_day'}</option>
+                                    <option value='2 Jan'>{'day_month'}</option>
                                     <option value='1 2'>{'month_day'}</option>
                                     <option value='2 1'>{'day_month'}</option>
                                     <option value='2006 1 2'>{'year_month_day'}</option>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -172,7 +172,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
                             >
                                 {'Prefixes may use underscore'}<code>{'_'}</code>{'.'} {'Other special characters including'} <code>{'-'}</code> {'are not allowed.'}
                             </div>
-                            {'Date would be appended to Hashtag Prefix, according to format chosen.'}
+                            {'Date would be appended to Hashtag Prefix, according to the chosen format.'}
                         </p>
                     </div>
                 </Modal.Body>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {Modal} from 'react-bootstrap';
 
-import Select from 'react-select'
+import Select from 'react-select';
 
 export default class MeetingSettingsModal extends React.PureComponent {
     static propTypes = {
@@ -16,18 +16,20 @@ export default class MeetingSettingsModal extends React.PureComponent {
     };
 
     options = [
-        { value: 'Jan 2', label: 'month_day' },
-        { value: '2 Jan', label: 'day_month' },
-        { value: '1 2', label: 'month_day' },
-        { value: '2 1', label: 'day_month' },
-        { value: '2006 1 2', label: 'year_month_day' },
+        {value: 'Jan 2', label: 'month_day'},
+        {value: '2 Jan', label: 'day_month'},
+        {value: '1 2', label: 'month_day'},
+        {value: '2 1', label: 'day_month'},
+        {value: '2006 1 2', label: 'year_month_day'},
     ];
 
     customStyles = {
-        menuList: (provided, state) => ({
-            ...provided,
-            height: 188
-        }),
+        menuList: (provided) => {
+            return ({
+                ...provided,
+                height: 188,
+            });
+        },
         control: (provided, state) => ({
             ...provided,
             height: 34,
@@ -35,19 +37,21 @@ export default class MeetingSettingsModal extends React.PureComponent {
             border: '1px solid #ced4da',
             boxShadow: state.isFocused ? 0 : '1px solid #ced4da',
             '&:hover': {
-                border: '1px solid #ced4da'
-            }
+                border: '1px solid #ced4da',
+            },
         }),
-        indicatorsContainer: (provided, state) => ({
-            ...provided,
-            height: 34,
-        }),
+        indicatorsContainer: (provided) => {
+            return ({
+                ...provided,
+                height: 34,
+            });
+        },
         singleValue: (provided, state) => {
             const opacity = state.isDisabled ? 0.5 : 1;
             const transition = 'opacity 300ms';
 
-            return { ...provided, opacity, transition };
-        }
+            return {...provided, opacity, transition};
+        },
     }
 
     constructor(props) {
@@ -69,7 +73,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
             const splitResult = this.props.meeting.hashtagFormat.split('{{');// we know, date Format is preceded by {{
             const hashtagPrefix = splitResult[0];
             const dateFormatValue = splitResult[1].substring(0, splitResult[1].length - 2).trim(); // remove trailing }}
-            const dateFormat = this.options.filter(i => i.value === dateFormatValue)[0]; // extract value object
+            const dateFormat = this.options.filter((i) => i.value === dateFormatValue)[0]; // extract value object
             // eslint-disable-next-line react/no-did-update-set-state
             this.setState({
                 hashtagPrefix,
@@ -85,8 +89,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
         });
     }
 
-    handleDateFormat = (newValue, actionMeta) => {
-        this.setState({ dateFormat: newValue });
+    handleDateFormat = (newValue) => {
+        this.setState({dateFormat: newValue});
     };
 
     handleCheckboxChanged = (e) => {

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import {Modal} from 'react-bootstrap';
 
+import Select from 'react-select'
+
 export default class MeetingSettingsModal extends React.PureComponent {
     static propTypes = {
         visible: PropTypes.bool.isRequired,
@@ -13,13 +15,48 @@ export default class MeetingSettingsModal extends React.PureComponent {
         saveMeetingSettings: PropTypes.func.isRequired,
     };
 
+    options = [
+        { value: 'Jan 2', label: 'month_day' },
+        { value: '2 Jan', label: 'day_month' },
+        { value: '1 2', label: 'month_day' },
+        { value: '2 1', label: 'day_month' },
+        { value: '2006 1 2', label: 'year_month_day' },
+    ];
+
+    customStyles = {
+        menuList: (provided, state) => ({
+            ...provided,
+            height: 188
+        }),
+        control: (provided, state) => ({
+            ...provided,
+            height: 34,
+            minHeight: 34,
+            border: '1px solid #ced4da',
+            boxShadow: state.isFocused ? 0 : '1px solid #ced4da',
+            '&:hover': {
+                border: '1px solid #ced4da'
+            }
+        }),
+        indicatorsContainer: (provided, state) => ({
+            ...provided,
+            height: 34,
+        }),
+        singleValue: (provided, state) => {
+            const opacity = state.isDisabled ? 0.5 : 1;
+            const transition = 'opacity 300ms';
+
+            return { ...provided, opacity, transition };
+        }
+    }
+
     constructor(props) {
         super(props);
 
         this.state = {
             hashtagPrefix: 'Prefix',
             weekdays: [1],
-            dateFormat: '1-2',
+            dateFormat: '1-2', // dateFormat will be an object type => { value: string, label: string }
         };
     }
 
@@ -31,7 +68,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
         if (this.props.meeting && this.props.meeting !== prevProps.meeting) {
             const splitResult = this.props.meeting.hashtagFormat.split('{{');// we know, date Format is preceded by {{
             const hashtagPrefix = splitResult[0];
-            const dateFormat = splitResult[1].substring(0, splitResult[1].length - 2); // remove trailing }}
+            const dateFormatValue = splitResult[1].substring(0, splitResult[1].length - 2).trim(); // remove trailing }}
+            const dateFormat = this.options.filter(i => i.value === dateFormatValue)[0]; // extract value object
             // eslint-disable-next-line react/no-did-update-set-state
             this.setState({
                 hashtagPrefix,
@@ -47,10 +85,8 @@ export default class MeetingSettingsModal extends React.PureComponent {
         });
     }
 
-    handleDateFormat = (event) => {
-        this.setState({
-            dateFormat: event.target.value,
-        });
+    handleDateFormat = (newValue, actionMeta) => {
+        this.setState({ dateFormat: newValue });
     };
 
     handleCheckboxChanged = (e) => {
@@ -73,7 +109,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
     onSave = () => {
         this.props.saveMeetingSettings({
             channelId: this.props.channelId,
-            hashtagFormat: `${this.state.hashtagPrefix}{{${this.state.dateFormat}}}`,
+            hashtagFormat: `${this.state.hashtagPrefix}{{${this.state.dateFormat.value}}}`,
             schedule: this.state.weekdays.sort(),
         });
 
@@ -119,7 +155,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
                         {'Channel Agenda Settings'}
                     </Modal.Title>
                 </Modal.Header>
-                <Modal.Body>
+                <Modal.Body style={{overflow: 'visible'}}>
                     <div className='form-group'>
                         <label className='control-label'>
                             {'Meeting Day'}
@@ -143,24 +179,19 @@ export default class MeetingSettingsModal extends React.PureComponent {
                             </div>
                             <div
                                 className='fifty'
-                                style={{padding: '5px'}}
+                                style={{padding: '5px', minWidth: '175px'}}
                             >
                                 <label className='control-label'>{'Date Format'}</label>
                                 <br/>
-                                <select
+                                <Select
                                     name='format'
-                                    value={this.state.dateFormat}
-                                    onChange={this.handleDateFormat}
-                                    style={{height: '35px', border: '1px solid #ced4da'}}
                                     className='form-select'
-                                >
-                                    <option value='Jan 2'>{'month_day'}</option>
-                                    <option value='2 Jan'>{'day_month'}</option>
-                                    <option value='1 2'>{'month_day'}</option>
-                                    <option value='2 1'>{'day_month'}</option>
-                                    <option value='2006 1 2'>{'year_month_day'}</option>
-
-                                </select>
+                                    styles={this.customStyles}
+                                    isSearchable={false}
+                                    value={this.state.dateFormat}
+                                    options={this.options}
+                                    onChange={this.handleDateFormat.bind(this)}
+                                />
                             </div>
                         </div>
 

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -170,7 +170,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
                                 role='alert'
                                 style={{marginBottom: '3px'}}
                             >
-                                {'You may use underscore'}<code>{'_'}</code>{'.'} {'Other special characters including'} <code>{'-'}</code>{','} {'not allowed.'}
+                                {'Prefixes may use underscore'}<code>{'_'}</code>{'.'} {'Other special characters including'} <code>{'-'}</code> {'are not allowed.'}
                             </div>
                             {'Date would be appended to Hashtag Prefix, according to format chosen.'}
                         </p>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-
-import {Modal} from 'react-bootstrap';
-
+import React from 'react';
+import { Modal } from 'react-bootstrap';
 import Select from 'react-select';
+
+
 
 export default class MeetingSettingsModal extends React.PureComponent {
     static propTypes = {
@@ -31,24 +31,24 @@ export default class MeetingSettingsModal extends React.PureComponent {
                 color: 'var(--center-channel-color)',
             };
         },
-        option: (provided, { isFocused, isDisabled, isSelected }) => {
-            const bgColor = isFocused
-                ? {
-                      backgroundColor: 'var(--button-bg)',
-                      color: 'var(--button-color)',
-                  }
-                : {};
+        option: (provided, {isFocused, isDisabled, isSelected}) => {
+            const bgColor = isFocused ?
+                {
+                    backgroundColor: 'var(--button-bg)',
+                    color: 'var(--button-color)',
+                }:
+                {};
 
             return {
                 ...provided,
                 ...bgColor,
                 ':active': {
                     ...provided[':active'],
-                    backgroundColor: !isDisabled
-                        ? isSelected
-                            ? 'var(--button-bg)'
-                            : 'var(--center-channel-bg)'
-                        : undefined,
+                    backgroundColor: isDisabled ?
+                    undefined :
+                    isSelected ?
+                    'var(--button-bg)':
+                    'var(--center-channel-bg)'
                 },
             };
         },
@@ -81,7 +81,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
             const transition = 'opacity 300ms';
             const color = 'var(--center-channel-color)';
             const background = 'var(--center-channel-bg)';
-            return { ...provided, opacity, transition, color, background };
+            return {...provided, opacity, transition, color, background};
         },
     }
 

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -17,8 +17,9 @@ export default class MeetingSettingsModal extends React.PureComponent {
         super(props);
 
         this.state = {
-            hashtag: '{{Jan02}}',
+            hashtagPrefix: 'Prefix',
             weekdays: [1],
+            dateFormat: '1-2',
         };
     }
 
@@ -28,9 +29,13 @@ export default class MeetingSettingsModal extends React.PureComponent {
         }
 
         if (this.props.meeting && this.props.meeting !== prevProps.meeting) {
+            const splitResult = this.props.meeting.hashtagFormat.split('{{');// we know, date Format is preceded by {{
+            const hashtagPrefix = splitResult[0];
+            const dateFormat = splitResult[1].substring(0, splitResult[1].length - 2); // remove trailing }}
             // eslint-disable-next-line react/no-did-update-set-state
             this.setState({
-                hashtag: this.props.meeting.hashtagFormat,
+                hashtagPrefix,
+                dateFormat,
                 weekdays: this.props.meeting.schedule || [],
             });
         }
@@ -38,9 +43,15 @@ export default class MeetingSettingsModal extends React.PureComponent {
 
     handleHashtagChange = (e) => {
         this.setState({
-            hashtag: e.target.value,
+            hashtagPrefix: e.target.value,
         });
     }
+
+    handleDateFormat = (event) => {
+        this.setState({
+            dateFormat: event.target.value,
+        });
+    };
 
     handleCheckboxChanged = (e) => {
         const changeday = Number(e.target.value);
@@ -62,7 +73,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
     onSave = () => {
         this.props.saveMeetingSettings({
             channelId: this.props.channelId,
-            hashtagFormat: this.state.hashtag,
+            hashtagFormat: `${this.state.hashtagPrefix}{{${this.state.dateFormat}}}`,
             schedule: this.state.weekdays.sort(),
         });
 
@@ -118,19 +129,50 @@ export default class MeetingSettingsModal extends React.PureComponent {
                         </div>
                     </div>
                     <div className='form-group'>
-                        <label className='control-label'>{'Hashtag Format'}</label>
-                        <input
-                            onChange={this.handleHashtagChange}
-                            className='form-control'
-                            value={this.state.hashtag ? this.state.hashtag : ''}
-                        />
-                        <p className='text-muted pt-1'> {'Hashtag is formatted using the '}
-                            <a
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href='https://godoc.org/time#pkg-constants'
-                            >{'Go time package.'}</a>
-                            {' Embed a date by surrounding what January 2, 2006 would look like with double curly braces, i.e. {{Jan02}}'}
+                        <div style={{display: 'flex'}}>
+                            <div
+                                className='fifty'
+                                style={{padding: '5px'}}
+                            >
+                                <label className='control-label'>{'Hashtag Prefix'}</label>
+                                <input
+                                    onChange={this.handleHashtagChange}
+                                    className='form-control'
+                                    value={this.state.hashtagPrefix ? this.state.hashtagPrefix : ''}
+                                />
+                            </div>
+                            <div
+                                className='fifty'
+                                style={{padding: '5px'}}
+                            >
+                                <label className='control-label'>{'Date Format'}</label>
+                                <br/>
+                                <select
+                                    name='format'
+                                    value={this.state.dateFormat}
+                                    onChange={this.handleDateFormat}
+                                    style={{height: '35px', border: '1px solid #ced4da'}}
+                                    className='form-select'
+                                >
+                                    <option value='Jan 2'>{'Month_day'}</option>
+                                    <option value='2 Jan'>{'day_Month'}</option>
+                                    <option value='1 2'>{'month_day'}</option>
+                                    <option value='2 1'>{'day_month'}</option>
+                                    <option value='2006 1 2'>{'year_month_day'}</option>
+
+                                </select>
+                            </div>
+                        </div>
+
+                        <p className='text-muted pt-1'>
+                            <div
+                                className='alert alert-warning'
+                                role='alert'
+                                style={{marginBottom: '3px'}}
+                            >
+                                {'You may use underscore'}<code>{'_'}</code>{'.'} {'Other special characters including'} <code>{'-'}</code>{','} {'not allowed.'}
+                            </div>
+                            {'Date would be appended to Hashtag Prefix, according to format chosen.'}
                         </p>
                     </div>
                 </Modal.Body>

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Modal } from 'react-bootstrap';
+import {Modal} from 'react-bootstrap';
 import Select from 'react-select';
-
-
 
 export default class MeetingSettingsModal extends React.PureComponent {
     static propTypes = {
@@ -36,7 +34,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
                 {
                     backgroundColor: 'var(--button-bg)',
                     color: 'var(--button-color)',
-                }:
+                } :
                 {};
 
             return {
@@ -44,11 +42,9 @@ export default class MeetingSettingsModal extends React.PureComponent {
                 ...bgColor,
                 ':active': {
                     ...provided[':active'],
-                    backgroundColor: isDisabled ?
-                    undefined :
-                    isSelected ?
-                    'var(--button-bg)':
-                    'var(--center-channel-bg)'
+                    backgroundColor: isSelected ?
+                    'var(--button-bg)' :
+                    'var(--center-channel-bg)',
                 },
             };
         },


### PR DESCRIPTION
#### Summary
Now, Hashtag of Agenda Items has two parts:
- Prefix
- Date Format (Dropdown of predefined items)
![Screenshot_76](https://user-images.githubusercontent.com/85980820/131073081-ffe9ef79-61e9-4ae3-9b7f-5db5341bef9d.png)

#### Testing notes
- Open agenda settings for the channel and enter desired prefix and choose date format.
- Create new agenda item in that group.(**`/agenda queue Task 1`**)

Output after chosen format:
![Screenshot_77](https://user-images.githubusercontent.com/85980820/131073487-29bf4312-f113-4d7e-9f5d-b1464ecd39f4.png)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-agenda/issues/66
Fixes https://github.com/mattermost/mattermost-plugin-agenda/issues/91
