### PR TITLE
[GH-12] Added Ability to re-queue agenda Items.

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -49,6 +50,9 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	case "queue":
 		return p.executeCommandQueue(args), nil
 
+	case "requeue":
+		return p.executeCommandReQueue(args), nil
+
 	case "setting":
 		return p.executeCommandSetting(args), nil
 
@@ -69,7 +73,7 @@ func (p *Plugin) executeCommandList(args *model.CommandArgs) *model.CommandRespo
 		weekday = int(parsedWeekday)
 	}
 
-	hashtag, err := p.GenerateHashtag(args.ChannelId, nextWeek, weekday)
+	hashtag, err := p.GenerateHashtag(args.ChannelId, nextWeek, weekday, false, time.Now().Weekday())
 	if err != nil {
 		return responsef("Error calculating hashtags")
 	}
@@ -147,31 +151,107 @@ func (p *Plugin) executeCommandQueue(args *model.CommandArgs) *model.CommandResp
 		message = strings.Join(split[3:], " ")
 	}
 
-	hashtag, error := p.GenerateHashtag(args.ChannelId, nextWeek, weekday)
+	hashtag, error := p.GenerateHashtag(args.ChannelId, nextWeek, weekday, false, time.Now().Weekday())
 	if error != nil {
 		return responsef("Error calculating hashtags. Check the meeting settings for this channel.")
 	}
 
-	searchResults, appErr := p.API.SearchPostsInTeamForUser(args.TeamId, args.UserId, model.SearchParameter{Terms: &hashtag})
-
-	if appErr != nil {
-		return responsef("Error calculating list number")
+	itemErr, numQueueItems := calculateQueItemNumber(args, p, hashtag)
+	if itemErr != nil {
+		return itemErr
 	}
 
-	postList := *searchResults.PostList
-	numQueueItems := len(postList.Posts)
-
-	_, appErr = p.API.CreatePost(&model.Post{
+	_, appErr := p.API.CreatePost(&model.Post{
 		UserId:    args.UserId,
 		ChannelId: args.ChannelId,
 		RootId:    args.RootId,
-		Message:   fmt.Sprintf("#### %v %v) %v", hashtag, numQueueItems+1, message),
+		Message:   fmt.Sprintf("#### %v %v) %v", hashtag, numQueueItems, message),
 	})
 	if appErr != nil {
 		return responsef("Error creating post: %s", appErr.Message)
 	}
 
 	return &model.CommandResponse{}
+}
+
+func calculateQueItemNumber(args *model.CommandArgs, p *Plugin, hashtag string) (*model.CommandResponse, int) {
+	searchResults, appErr := p.API.SearchPostsInTeamForUser(args.TeamId, args.UserId, model.SearchParameter{Terms: &hashtag})
+	if appErr != nil {
+		return responsef("Error calculating list number"), 0
+	}
+	postList := *searchResults.PostList
+	numQueueItems := len(postList.Posts)
+	return nil, numQueueItems + 1
+}
+
+func (p *Plugin) executeCommandReQueue(args *model.CommandArgs) *model.CommandResponse {
+	split := strings.Fields(args.Command)
+
+	if len(split) <= 2 {
+		return responsef("Missing parameters for requeue command")
+	}
+
+	meeting, err := p.GetMeeting(args.ChannelId)
+	if err != nil {
+		return responsef("Can't find the meeting")
+	}
+
+	oldPostID := split[2]
+	postToBeReQueued, _ := p.API.GetPost(oldPostID)
+	var (
+		prefix            string
+		hashtagDateFormat string
+	)
+	if matchGroups := meetingDateFormatRegex.FindStringSubmatch(meeting.HashtagFormat); len(matchGroups) == 4 {
+		prefix = matchGroups[1]
+		hashtagDateFormat = strings.TrimSpace(matchGroups[2])
+	} else {
+		return responsef("Error 203")
+	}
+
+	var (
+		messageRegexFormat = regexp.MustCompile(fmt.Sprintf(`(?m)^#### #%s(?P<date>.*) [0-9]+\) (?P<message>.*)?$`, prefix))
+	)
+
+	if matchGroups := messageRegexFormat.FindStringSubmatch(postToBeReQueued.Message); len(matchGroups) == 3 {
+		originalPostDate := strings.ReplaceAll(strings.TrimSpace(matchGroups[1]), "_", " ") // reverse what we do to make it a valid hashtag
+		originalPostMessage := strings.TrimSpace(matchGroups[2])
+
+		today := time.Now()
+		local, _ := time.LoadLocation("Local")
+		formattedDate, _ := time.ParseInLocation(hashtagDateFormat, originalPostDate, local)
+		if formattedDate.Year() == 0 {
+			thisYear := today.Year()
+			formattedDate = formattedDate.AddDate(thisYear, 0, 0)
+		}
+
+		if today.Year() <= formattedDate.Year() && today.YearDay() < formattedDate.YearDay() {
+			return responsef("We don't support re-queuing future items, only available for present and past items.")
+		}
+
+		hashtag, error := p.GenerateHashtag(args.ChannelId, false, -1, true, formattedDate.Weekday())
+		if error != nil {
+			return responsef("Error calculating hashtags. Check the meeting settings for this channel.")
+		}
+
+		itemErr, numQueueItems := calculateQueItemNumber(args, p, hashtag)
+		if itemErr != nil {
+			return itemErr
+		}
+
+		_, appErr := p.API.UpdatePost(&model.Post{
+			Id:        oldPostID,
+			UserId:    args.UserId,
+			ChannelId: args.ChannelId,
+			RootId:    args.RootId,
+			Message:   fmt.Sprintf("#### %v %v) %v", hashtag, numQueueItems, originalPostMessage),
+		})
+		if appErr != nil {
+			return responsef("Error creating post: %s", appErr.Message)
+		}
+		return &model.CommandResponse{Text: fmt.Sprintf("Item has been Re-queued to %v", hashtag), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+	return responsef("Make sure, message is in required format!")
 }
 
 func (p *Plugin) executeCommandHelp(args *model.CommandArgs) *model.CommandResponse {

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -16,7 +16,7 @@ var (
 type Meeting struct {
 	ChannelID     string         `json:"channelId"`
 	Schedule      []time.Weekday `json:"schedule"`
-	HashtagFormat string         `json:"hashtagFormat"` // Default: {ChannelName}-Jan02
+	HashtagFormat string         `json:"hashtagFormat"` // Default: {ChannelName}-Jan-2
 }
 
 // GetMeeting returns a meeting
@@ -37,9 +37,10 @@ func (p *Plugin) GetMeeting(channelID string) (*Meeting, error) {
 		if err != nil {
 			return nil, err
 		}
+		paddedChannelName := strings.ReplaceAll(channel.Name, "-", "_")
 		meeting = &Meeting{
 			Schedule:      []time.Weekday{time.Thursday},
-			HashtagFormat: strings.Join([]string{fmt.Sprintf("%.15s", channel.Name), "{{ Jan02 }}"}, "-"),
+			HashtagFormat: strings.Join([]string{fmt.Sprintf("%.15s", paddedChannelName), "{{ Jan 2 }}"}, "_"),
 			ChannelID:     channelID,
 		}
 	}
@@ -92,8 +93,10 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int) (
 		prefix = matchGroups[1]
 		hashtagFormat = strings.TrimSpace(matchGroups[2])
 		postfix = matchGroups[3]
+		formattedDate := meetingDate.Format(hashtagFormat)
+		formattedDate = strings.ReplaceAll(formattedDate, " ", "_")
 
-		hashtag = fmt.Sprintf("#%s%v%s", prefix, meetingDate.Format(hashtagFormat), postfix)
+		hashtag = fmt.Sprintf("#%s%v%s", prefix, formattedDate, postfix)
 	} else {
 		hashtag = fmt.Sprintf("#%s", meeting.HashtagFormat)
 	}

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -138,7 +138,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 			jsonMeeting, err := json.Marshal(tt.args.meeting)
 			tAssert.Nil(err)
 			api.On("KVGet", tt.args.meeting.ChannelID).Return(jsonMeeting, nil)
-			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, -1)
+			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, -1, false, time.Now().Weekday()) // last parameter doesn't matter unless requeue
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateHashtag() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -55,9 +55,9 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 				meeting: &Meeting{
 					ChannelID:     "QA",
 					Schedule:      []time.Weekday{time.Wednesday},
-					HashtagFormat: "{{Jan02}}",
+					HashtagFormat: "{{Jan 2}}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Wednesday, true).Format("Jan02"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Wednesday, true).Format("Jan 2"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -67,9 +67,9 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 				meeting: &Meeting{
 					ChannelID:     "QA Backend",
 					Schedule:      []time.Weekday{time.Monday},
-					HashtagFormat: "QA-{{January 02 2006}}",
+					HashtagFormat: "QA_{{January 02 2006}}",
 				}},
-			want:    "#QA-" + assertNextWeekdayDate(time.Monday, true).Format("January 02 2006"),
+			want:    "#QA_" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, true).Format("January 02 2006"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -81,7 +81,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "{{January 02 2006}}.vue",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + ".vue",
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + ".vue",
 			wantErr: false,
 		},
 		{
@@ -93,7 +93,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "React {{January 02 2006}} Born",
 				}},
-			want:    "#React " + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + " Born",
+			want:    "#React " + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + " Born",
 			wantErr: false,
 		},
 		{
@@ -105,7 +105,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "January 02 2006 {{January 02 2006}} January 02 2006",
 				}},
-			want:    "#January 02 2006 " + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006") + " January 02 2006",
+			want:    "#January 02 2006 " + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_") + " January 02 2006",
 			wantErr: false,
 		},
 		{
@@ -117,7 +117,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:  []time.Weekday{time.Monday},
 					HashtagFormat: "{{   January 02 2006			}}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"), " ", "_"),
 			wantErr: false,
 		},
 		{
@@ -129,7 +129,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "{{ Mon Jan _2 }}",
 				}},
-			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("Mon Jan _2"),
+			want:    "#" + strings.ReplaceAll(assertNextWeekdayDate(time.Monday, false).Format("Mon Jan _2"), " ", "_"),
 			wantErr: false,
 		},
 	}
@@ -176,7 +176,7 @@ func TestPlugin_GetMeeting(t *testing.T) {
 			},
 			want: &Meeting{
 				Schedule:      []time.Weekday{time.Thursday},
-				HashtagFormat: "Short-{{ Jan02 }}",
+				HashtagFormat: "Short_{{ Jan 2 }}",
 				ChannelID:     "#short.name.channel",
 			},
 			wantErr: false,
@@ -190,7 +190,7 @@ func TestPlugin_GetMeeting(t *testing.T) {
 			},
 			want: &Meeting{
 				Schedule:      []time.Weekday{time.Thursday},
-				HashtagFormat: "Very Long Chann-{{ Jan02 }}",
+				HashtagFormat: "Very Long Chann_{{ Jan 2 }}",
 				ChannelID:     "#long.name.channel",
 			},
 			wantErr: false,

--- a/server/utils.go
+++ b/server/utils.go
@@ -72,6 +72,25 @@ func nextWeekdayDateInWeek(meetingDays []time.Weekday, nextWeek bool) (*time.Tim
 	return nextWeekdayDate(meetingDay, nextWeek)
 }
 
+func nextWeekdayDateInWeekSkippingDay(meetingDays []time.Weekday, nextWeek bool, dayToSkip time.Weekday) (*time.Time, error) {
+	if len(meetingDays) == 0 {
+		return nil, errors.New("missing weekdays to calculate date")
+	}
+
+	todayWeekday := time.Now().Weekday()
+
+	// Find which meeting weekday to calculate the date for
+	meetingDay := meetingDays[0]
+	for _, day := range meetingDays {
+		if todayWeekday <= day && day != dayToSkip {
+			meetingDay = day
+			break
+		}
+	}
+
+	return nextWeekdayDate(meetingDay, nextWeek)
+}
+
 // nextWeekdayDate calculates the date of the next given weekday
 // from today's date.
 // If nextWeek is true, it will be based on the next calendar week.

--- a/webapp/src/components/meeting_settings/meeting_settings.jsx
+++ b/webapp/src/components/meeting_settings/meeting_settings.jsx
@@ -17,8 +17,9 @@ export default class MeetingSettingsModal extends React.PureComponent {
         super(props);
 
         this.state = {
-            hashtag: '{{Jan02}}',
+            hashtagPrefix: 'Prefix',
             weekdays: [1],
+            dateFormat: '1-2',
         };
     }
 
@@ -28,9 +29,13 @@ export default class MeetingSettingsModal extends React.PureComponent {
         }
 
         if (this.props.meeting && this.props.meeting !== prevProps.meeting) {
+            const splitResult = this.props.meeting.hashtagFormat.split('{{');// we know, date Format is preceded by {{
+            const hashtagPrefix = splitResult[0];
+            const dateFormat = splitResult[1].substring(0, splitResult[1].length - 2); // remove trailing }}
             // eslint-disable-next-line react/no-did-update-set-state
             this.setState({
-                hashtag: this.props.meeting.hashtagFormat,
+                hashtagPrefix,
+                dateFormat,
                 weekdays: this.props.meeting.schedule || [],
             });
         }
@@ -38,9 +43,15 @@ export default class MeetingSettingsModal extends React.PureComponent {
 
     handleHashtagChange = (e) => {
         this.setState({
-            hashtag: e.target.value,
+            hashtagPrefix: e.target.value,
         });
     }
+
+    handleDateFormat = (event) => {
+        this.setState({
+            dateFormat: event.target.value,
+        });
+    };
 
     handleCheckboxChanged = (e) => {
         const changeday = Number(e.target.value);
@@ -62,7 +73,7 @@ export default class MeetingSettingsModal extends React.PureComponent {
     onSave = () => {
         this.props.saveMeetingSettings({
             channelId: this.props.channelId,
-            hashtagFormat: this.state.hashtag,
+            hashtagFormat: `${this.state.hashtagPrefix}{{${this.state.dateFormat}}}`,
             schedule: this.state.weekdays.sort(),
         });
 
@@ -118,19 +129,50 @@ export default class MeetingSettingsModal extends React.PureComponent {
                         </div>
                     </div>
                     <div className='form-group'>
-                        <label className='control-label'>{'Hashtag Format'}</label>
-                        <input
-                            onChange={this.handleHashtagChange}
-                            className='form-control'
-                            value={this.state.hashtag ? this.state.hashtag : ''}
-                        />
-                        <p className='text-muted pt-1'> {'Hashtag is formatted using the '}
-                            <a
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href='https://godoc.org/time#pkg-constants'
-                            >{'Go time package.'}</a>
-                            {' Embed a date by surrounding what January 2, 2006 would look like with double curly braces, i.e. {{Jan02}}'}
+                        <div style={{display: 'flex'}}>
+                            <div
+                                className='fifty'
+                                style={{padding: '5px'}}
+                            >
+                                <label className='control-label'>{'Hashtag Prefix'}</label>
+                                <input
+                                    onChange={this.handleHashtagChange}
+                                    className='form-control'
+                                    value={this.state.hashtagPrefix ? this.state.hashtagPrefix : ''}
+                                />
+                            </div>
+                            <div
+                                className='fifty'
+                                style={{padding: '5px'}}
+                            >
+                                <label className='control-label'>{'Date Format'}</label>
+                                <br/>
+                                <select
+                                    name='format'
+                                    value={this.state.dateFormat}
+                                    onChange={this.handleDateFormat}
+                                    style={{height: '35px', border: '1px solid #ced4da'}}
+                                    className='form-select'
+                                >
+                                    <option value='Jan 2'>{'Month_day'}</option>
+                                    <option value='2 Jan'>{'day_Month'}</option>
+                                    <option value='1 2'>{'month_day'}</option>
+                                    <option value='2 1'>{'day_month'}</option>
+                                    <option value='2006 1 2'>{'year_month_day'}</option>
+
+                                </select>
+                            </div>
+                        </div>
+
+                        <p className='text-muted pt-1'>
+                            <div
+                                className='alert alert-warning'
+                                role='alert'
+                                style={{marginBottom: '3px'}}
+                            >
+                                {'You may use underscore'}<code>{'_'}</code>{'.'} {'Other special characters including'} <code>{'-'}</code>{','} {'not allowed.'}
+                            </div>
+                            {'Date would be appended to Hashtag Prefix, according to format chosen.'}
                         </p>
                     </div>
                 </Modal.Body>

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,5 +1,5 @@
 
-import {updateSearchTerms, updateSearchResultsTerms, updateRhsState, performSearch, openMeetingSettingsModal} from './actions';
+import {updateSearchTerms, updateSearchResultsTerms, updateRhsState, performSearch, openMeetingSettingsModal, requeueItem} from './actions';
 
 import reducer from './reducer';
 
@@ -19,6 +19,10 @@ export default class Plugin {
             (channelId) => {
                 store.dispatch(openMeetingSettingsModal(channelId));
             });
+
+        registry.registerPostDropdownMenuAction('Re-queue', (params) => {
+            store.dispatch(requeueItem(params));
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #12 

#### Summary
- Now old agenda items could be re-queued to upcoming meetings.
#### Testing notes
- Create multiple agenda items for past date according to channel Hash Format.(You may create a message and edit its date manually)
- open RHS menu on any of these and click Re-queue
![Screenshot_78](https://user-images.githubusercontent.com/85980820/131095909-1a90a67f-8d69-44fa-9064-af475b39a085.png)
Result:
It will be requeued to upcoming meeting date.
![Screenshot_79](https://user-images.githubusercontent.com/85980820/131096033-ac29186c-a5a9-4b50-bde8-f71978d6f365.png)


#### Ticket Link
https://github.com/mattermost/mattermost-plugin-agenda/issues/12

