### PR TITLE
[GH-12] Added Ability to re-queue agenda Items.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,22 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - plugin-ci/test:
+          filters:
+            tags:
+              only: /^v.*/
       - plugin-ci/coverage:
           filters:
             tags:
               only: /^v.*/
+          requires:
+            - plugin-ci/test
       - plugin-ci/build:
           filters:
             tags:
               only: /^v.*/
+          requires:
+            - plugin-ci/test
       - plugin-ci/deploy-ci:
           filters:
             branches:
@@ -40,6 +48,7 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/coverage
             - plugin-ci/build
+            - plugin-ci/test
       - plugin-ci/deploy-release-github:
           filters:
             tags:
@@ -51,3 +60,4 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/coverage
             - plugin-ci/build
+            - plugin-ci/test

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
+	github.com/undefinedlabs/go-mpatch v1.0.6
 )

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+github.com/undefinedlabs/go-mpatch v1.0.6 h1:h8q5ORH/GaOE1Se1DMhrOyljXZEhRcROO7agMqWXCOY=
+github.com/undefinedlabs/go-mpatch v1.0.6/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBnvPM1Su9w=

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -75,15 +75,12 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int, r
 			return "", err
 		}
 	} else {
-		// user didn't provide any specific date, Get date for the list of days of the week
+		// user didn't specify any specific date/day in command, Get date for the list of days of the week
 		if !requeue {
 			if meetingDate, err = nextWeekdayDateInWeek(meeting.Schedule, nextWeek); err != nil {
 				return "", err
 			}
 		} else {
-			if len(meeting.Schedule) == 1 && meeting.Schedule[0] == assignedDay { // if this day is the only day selected in settings
-				nextWeek = true
-			}
 			if meetingDate, err = nextWeekdayDateInWeekSkippingDay(meeting.Schedule, nextWeek, assignedDay); err != nil {
 				return "", err
 			}

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	meetingDateFormatRegex = regexp.MustCompile(`(?m)^(?P<prefix>.*)?(?:{{\s*(?P<dateformat>.*)\s*}})(?P<postfix>.*)?$`)
+	meetingDateFormatRegex, appErr = regexp.Compile(`(?m)^(?P<prefix>.*)?(?:{{\s*(?P<dateformat>.*)\s*}})(?P<postfix>.*)?$`)
 )
 
 // Meeting represents a meeting agenda
@@ -139,6 +139,10 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int, r
 	}
 
 	var hashtag string
+
+	if appErr != nil {
+		return "", appErr
+	}
 
 	if matchGroups := meetingDateFormatRegex.FindStringSubmatch(meeting.HashtagFormat); len(matchGroups) == 4 {
 		var (

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -62,7 +62,7 @@ func (p *Plugin) SaveMeeting(meeting *Meeting) error {
 }
 
 // GenerateHashtag returns a meeting hashtag
-func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int) (string, error) {
+func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int, requeue bool, assignedDay time.Weekday) (string, error) {
 	meeting, err := p.GetMeeting(channelID)
 	if err != nil {
 		return "", err
@@ -75,9 +75,18 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int) (
 			return "", err
 		}
 	} else {
-		// Get date for the list of days of the week
-		if meetingDate, err = nextWeekdayDateInWeek(meeting.Schedule, nextWeek); err != nil {
-			return "", err
+		// user didn't provide any specific date, Get date for the list of days of the week
+		if !requeue {
+			if meetingDate, err = nextWeekdayDateInWeek(meeting.Schedule, nextWeek); err != nil {
+				return "", err
+			}
+		} else {
+			if len(meeting.Schedule) == 1 && meeting.Schedule[0] == assignedDay { // if this day is the only day selected in settings
+				nextWeek = true
+			}
+			if meetingDate, err = nextWeekdayDateInWeekSkippingDay(meeting.Schedule, nextWeek, assignedDay); err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	meetingDateFormatRegex, appErr = regexp.Compile(`(?m)^(?P<prefix>.*)?(?:{{\s*(?P<dateformat>.*)\s*}})(?P<postfix>.*)?$`)
+	meetingDateFormatRegex = regexp.MustCompile(`(?m)^(?P<prefix>.*)?(?:{{\s*(?P<dateformat>.*)\s*}})(?P<postfix>.*)?$`)
 )
 
 // Meeting represents a meeting agenda
@@ -139,10 +139,6 @@ func (p *Plugin) GenerateHashtag(channelID string, nextWeek bool, weekday int, r
 	}
 
 	var hashtag string
-
-	if appErr != nil {
-		return "", appErr
-	}
 
 	if matchGroups := meetingDateFormatRegex.FindStringSubmatch(meeting.HashtagFormat); len(matchGroups) == 4 {
 		var (

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -138,7 +138,7 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 			jsonMeeting, err := json.Marshal(tt.args.meeting)
 			tAssert.Nil(err)
 			api.On("KVGet", tt.args.meeting.ChannelID).Return(jsonMeeting, nil)
-			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, -1)
+			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, -1, false, 1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateHashtag() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -138,7 +138,10 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 			jsonMeeting, err := json.Marshal(tt.args.meeting)
 			tAssert.Nil(err)
 			api.On("KVGet", tt.args.meeting.ChannelID).Return(jsonMeeting, nil)
-			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, -1, false, 1)
+			weekday := -1
+			requeue := false
+			assignedDay := time.Weekday(1)
+			got, err := mPlugin.GenerateHashtag(tt.args.meeting.ChannelID, tt.args.nextWeek, weekday, requeue, assignedDay)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateHashtag() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/utils.go
+++ b/server/utils.go
@@ -72,6 +72,25 @@ func nextWeekdayDateInWeek(meetingDays []time.Weekday, nextWeek bool) (*time.Tim
 	return nextWeekdayDate(meetingDay, nextWeek)
 }
 
+func nextWeekdayDateInWeekSkippingDay(meetingDays []time.Weekday, nextWeek bool, dayToSkip time.Weekday) (*time.Time, error) {
+	if len(meetingDays) == 0 {
+		return nil, errors.New("missing weekdays to calculate date")
+	}
+
+	todayWeekday := time.Now().Weekday()
+
+	// Find which meeting weekday to calculate the date for
+	meetingDay := meetingDays[0]
+	for _, day := range meetingDays {
+		if todayWeekday <= day && day != dayToSkip {
+			meetingDay = day
+			break
+		}
+	}
+
+	return nextWeekdayDate(meetingDay, nextWeek)
+}
+
 // nextWeekdayDate calculates the date of the next given weekday
 // from today's date.
 // If nextWeek is true, it will be based on the next calendar week.

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -85,7 +85,7 @@ export function performSearch(terms) {
 
 export function requeueItem(postId) {
     return async (dispatch, getState) => {
-        const command = `/agenda requeue ${postId}`;
+        const command = `/agenda requeue post ${postId}`;
         await clientExecuteCommand(dispatch, getState, command);
         return {data: true};
     };

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -83,17 +83,18 @@ export function performSearch(terms) {
     };
 }
 
-export function requeueItem(itemId) {
+export function requeueItem(postId) {
     return async (dispatch, getState) => {
-        const command = `/agenda requeue ${itemId}`;
+        const command = `/agenda requeue ${postId}`;
         await clientExecuteCommand(dispatch, getState, command);
         return {data: true};
     };
 }
 
 export async function clientExecuteCommand(dispatch, getState, command) {
-    const currentChannel = getCurrentChannel(getState());
-    const currentTeamId = getCurrentTeamId(getState());
+    const state = getState();
+    const currentChannel = getCurrentChannel(state);
+    const currentTeamId = getCurrentTeamId(state);
     const args = {
         channel_id: currentChannel?.id,
         team_id: currentTeamId,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -1,7 +1,8 @@
 import {searchPostsWithParams} from 'mattermost-redux/actions/search';
-
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {Client4} from 'mattermost-redux/client';
 
 import Client from '../client';
 
@@ -80,4 +81,27 @@ export function performSearch(terms) {
 
         return dispatch(searchPostsWithParams(teamId, {terms, is_or_search: false, include_deleted_channels: viewArchivedChannels, page: 0, per_page: 20}, true));
     };
+}
+
+export function requeueItem(itemId) {
+    return async (dispatch, getState) => {
+        const command = `/agenda requeue ${itemId}`;
+        await clientExecuteCommand(dispatch, getState, command);
+        return {data: true};
+    };
+}
+
+export async function clientExecuteCommand(dispatch, getState, command) {
+    const currentChannel = getCurrentChannel(getState());
+    const currentTeamId = getCurrentTeamId(getState());
+    const args = {
+        channel_id: currentChannel?.id,
+        team_id: currentTeamId,
+    };
+
+    try {
+        return Client4.executeCommand(command, args);
+    } catch (error) {
+        return error;
+    }
 }

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,5 +1,5 @@
 
-import {updateSearchTerms, updateSearchResultsTerms, updateRhsState, performSearch, openMeetingSettingsModal} from './actions';
+import {updateSearchTerms, updateSearchResultsTerms, updateRhsState, performSearch, openMeetingSettingsModal, requeueItem} from './actions';
 
 import reducer from './reducer';
 
@@ -19,6 +19,10 @@ export default class Plugin {
             (channelId) => {
                 store.dispatch(openMeetingSettingsModal(channelId));
             });
+
+        registry.registerPostDropdownMenuAction('Re-queue', (itemId) => {
+            store.dispatch(requeueItem(itemId));
+        });
     }
 }
 

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -20,8 +20,8 @@ export default class Plugin {
                 store.dispatch(openMeetingSettingsModal(channelId));
             });
 
-        registry.registerPostDropdownMenuAction('Re-queue', (itemId) => {
-            store.dispatch(requeueItem(itemId));
+        registry.registerPostDropdownMenuAction('Re-queue', (postId) => {
+            store.dispatch(requeueItem(postId));
         });
     }
 }


### PR DESCRIPTION
Fixes #12 

#### Summary
- Now old agenda items could be re-queued to upcoming meetings.
#### Testing notes
- Create multiple agenda items for past date according to channel Hash Format.(You may create a message and edit its date manually)
- open RHS menu on any of these and click Re-queue
![Screenshot_78](https://user-images.githubusercontent.com/85980820/131095909-1a90a67f-8d69-44fa-9064-af475b39a085.png)
Result:
It will be requeued to upcoming meeting date.
![Screenshot_79](https://user-images.githubusercontent.com/85980820/131096033-ac29186c-a5a9-4b50-bde8-f71978d6f365.png)


#### Ticket Link
https://github.com/mattermost/mattermost-plugin-agenda/issues/12

