### PR TITLE
[GH-47] [FIX] Agenda item number should get updated if the items of the agenda are deleted

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +17,13 @@ const (
 
 	wsEventList = "list"
 )
+
+// ParsedMeetingMessage is meeting message after being parsed
+type ParsedMeetingMessage struct {
+	date        string
+	number      string // TODO we don't need it right now
+	textMessage string
+}
 
 const helpCommandText = "###### Mattermost Agenda Plugin - Slash Command Help\n" +
 	"The Agenda plugin lets you queue up meeting topics for channel discussion at a later time.  When your meeting happens, you can click on the Hashtag to see all agenda items in the RHS. \n" +
@@ -132,6 +141,11 @@ func (p *Plugin) executeCommandQueue(args *model.CommandArgs) *model.CommandResp
 		return responsef("Missing parameters for queue command")
 	}
 
+	meeting, err := p.GetMeeting(args.ChannelId)
+	if err != nil {
+		return responsef("Can't find the meeting")
+	}
+
 	nextWeek := false
 	weekday := -1
 	message := strings.Join(split[2:], " ")
@@ -152,26 +166,85 @@ func (p *Plugin) executeCommandQueue(args *model.CommandArgs) *model.CommandResp
 		return responsef("Error calculating hashtags. Check the meeting settings for this channel.")
 	}
 
-	searchResults, appErr := p.API.SearchPostsInTeamForUser(args.TeamId, args.UserId, model.SearchParameter{Terms: &hashtag})
-
-	if appErr != nil {
-		return responsef("Error calculating list number")
+	numQueueItems, itemErr := calculateQueItemNumberAndUpdateOldItems(meeting, args, p, hashtag)
+	if itemErr != nil {
+		return itemErr
 	}
 
-	postList := *searchResults.PostList
-	numQueueItems := len(postList.Posts)
-
-	_, appErr = p.API.CreatePost(&model.Post{
+	_, appErr := p.API.CreatePost(&model.Post{
 		UserId:    args.UserId,
 		ChannelId: args.ChannelId,
 		RootId:    args.RootId,
-		Message:   fmt.Sprintf("#### %v %v) %v", hashtag, numQueueItems+1, message),
+		Message:   fmt.Sprintf("#### %v %v) %v", hashtag, numQueueItems, message),
 	})
 	if appErr != nil {
 		return responsef("Error creating post: %s", appErr.Message)
 	}
 
 	return &model.CommandResponse{}
+}
+
+func calculateQueItemNumberAndUpdateOldItems(meeting *Meeting, args *model.CommandArgs, p *Plugin, hashtag string) (int, *model.CommandResponse) {
+	searchResults, appErr := p.API.SearchPostsInTeamForUser(args.TeamId, args.UserId, model.SearchParameter{Terms: &hashtag})
+	if appErr != nil {
+		return 0, responsef("Error calculating list number")
+	}
+
+	counter := 1
+
+	var sortedPosts []*model.Post
+	// TODO we won't need to do this once we fix https://github.com/mattermost/mattermost-server/issues/11006
+	for _, post := range searchResults.PostList.Posts {
+		sortedPosts = append(sortedPosts, post)
+	}
+
+	sort.Slice(sortedPosts, func(i, j int) bool {
+		return sortedPosts[i].CreateAt < sortedPosts[j].CreateAt
+	})
+
+	for _, post := range sortedPosts {
+		_, parsedMessage, _ := parseMeetingPost(meeting, post)
+		_, findErr := p.API.UpdatePost(&model.Post{
+			Id:        post.Id,
+			UserId:    args.UserId,
+			ChannelId: args.ChannelId,
+			RootId:    args.RootId,
+			Message:   fmt.Sprintf("#### %v %v) %v", hashtag, counter, parsedMessage.textMessage),
+		})
+		counter++
+		if findErr != nil {
+			return 0, responsef("Error updating post: %s", findErr.Message)
+		}
+	}
+	return counter, nil
+}
+
+func parseMeetingPost(meeting *Meeting, post *model.Post) (string, ParsedMeetingMessage, *model.CommandResponse) {
+	var (
+		prefix            string
+		hashtagDateFormat string
+	)
+	if matchGroups := meetingDateFormatRegex.FindStringSubmatch(meeting.HashtagFormat); len(matchGroups) == 4 {
+		prefix = matchGroups[1]
+		hashtagDateFormat = strings.TrimSpace(matchGroups[2])
+	} else {
+		return "", ParsedMeetingMessage{}, responsef("Error 267")
+	}
+
+	var (
+		messageRegexFormat = regexp.MustCompile(fmt.Sprintf(`(?m)^#### #%s(?P<date>.*) ([0-9]+)\) (?P<message>.*)?$`, prefix))
+	)
+
+	matchGroups := messageRegexFormat.FindStringSubmatch(post.Message)
+	if len(matchGroups) == 4 {
+		parsedMeetingMessage := ParsedMeetingMessage{
+			date:        matchGroups[1],
+			number:      matchGroups[2],
+			textMessage: matchGroups[3],
+		}
+		return hashtagDateFormat, parsedMeetingMessage, nil
+	}
+	return hashtagDateFormat, ParsedMeetingMessage{}, responsef("An error occurred processing the meeting hashtag.")
 }
 
 func (p *Plugin) executeCommandHelp(args *model.CommandArgs) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -20,7 +20,7 @@ const (
 // ParsedMeetingMessage is meeting message after being parsed
 type ParsedMeetingMessage struct {
 	date        string
-	number      string // TODO we don't need it right now
+	number      string
 	textMessage string
 }
 
@@ -142,7 +142,7 @@ func (p *Plugin) executeCommandQueue(args *model.CommandArgs) *model.CommandResp
 
 	meeting, err := p.GetMeeting(args.ChannelId)
 	if err != nil {
-		p.API.LogError("failed to get meeting for channel", "err", err.Error(), "channel_id:", args.ChannelId)
+		p.API.LogError("failed to get meeting for channel", "err", err.Error(), "channel_id", args.ChannelId)
 	}
 
 	nextWeek := false

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/pkg/errors"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/server/meeting.go
+++ b/server/meeting.go
@@ -73,7 +73,7 @@ func (p *Plugin) calculateQueueItemNumberAndUpdateOldItems(meeting *Meeting, arg
 	terms := fmt.Sprintf("in:%s %s", c.Name, hashtag)
 	searchResults, appErr := p.API.SearchPostsInTeamForUser(args.TeamId, args.UserId, model.SearchParameter{Terms: &terms})
 	if appErr != nil {
-		return 0, errors.Wrap(appErr, "Error calculating list number")
+		return 0, errors.Wrap(appErr, "Error searching posts to find hashtags")
 	}
 
 	counter := 1
@@ -102,10 +102,10 @@ func (p *Plugin) calculateQueueItemNumberAndUpdateOldItems(meeting *Meeting, arg
 			RootId:    post.RootId,
 			Message:   fmt.Sprintf("#### %v %v) %v", hashtag, counter, parsedMessage.textMessage),
 		})
-
 		if updateErr != nil {
 			return 0, errors.Wrap(updateErr, "Error updating post")
 		}
+
 		counter++
 	}
 


### PR DESCRIPTION
#### Summary
Fixes #47 
Now, Whenever we add new agenda item. Plugin searches for old messages for that hashtag. 
If some item is missing(deleted), it fixes numbering for all items. 

#### Testing
Ensure that the agenda plugin is installed and enabled.
Go to a channel header and edit the agenda settings to update the prefix and 
Use command /agenda queue to queue at least 3 items as following:
`/agenda queue item 1`
`/agenda queue item 2`
`/agenda queue item 3`

Click on the agenda hashtag to open up the agenda list on the RHS.
On the RHS, click the post menu for item 1 (or the first item that was queued) and delete the agenda item.
**Ensure that now there are only 2 items for that agenda hashtag: item 2 and item 3 on the RHS.**
Add a new agenda item: /agenda queue new item.
Click on the hashtag to refresh the RHS.

Outcome: The RHS has 3 agenda items numbered 1), 2) and 3)

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-agenda/issues/47
****