### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,18 +3,15 @@ run:
   modules-download-mode: readonly
 
 linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 3
   gofmt:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-plugin-agenda
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
   misspell:
     locale: US
 
@@ -22,41 +19,33 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
-    - goconst
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:
   exclude-rules:
     - path: server/manifest.go
       linters:
-        - deadcode
         - unused
-        - varcheck
     - path: server/configuration.go
       linters:
         - unused
     - path: _test\.go
       linters:
         - bodyclose
-        - goconst
         - scopelint # https://github.com/kyoh86/scopelint/issues/4

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -692,8 +692,9 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/server/meeting_test.go
+++ b/server/meeting_test.go
@@ -113,8 +113,8 @@ func TestPlugin_GenerateHashtag(t *testing.T) {
 			args: args{
 				nextWeek: false,
 				meeting: &Meeting{
-					ChannelID: "Dates with Spaces",
-					Schedule:  []time.Weekday{time.Monday},
+					ChannelID:     "Dates with Spaces",
+					Schedule:      []time.Weekday{time.Monday},
 					HashtagFormat: "{{   January 02 2006			}}",
 				}},
 			want:    "#" + assertNextWeekdayDate(time.Monday, false).Format("January 02 2006"),


### PR DESCRIPTION
#### Summary
Fix linter errors caused by `golangci-lint` update

#### Ticket Link
None