### PR TITLE
chore: Fix linter errors

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -41,7 +41,7 @@ func (p *Plugin) registerCommands() error {
 }
 
 // ExecuteCommand executes a command that has been previously registered via the RegisterCommand
-func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	split := strings.Fields(args.Command)
 
 	if len(split) < 2 {
@@ -216,7 +216,7 @@ func parseMeetingPost(meeting *Meeting, post *model.Post) (string, ParsedMeeting
 	return hashtagDateFormat, ParsedMeetingMessage{}, errors.New("failed to parse meeting post's header")
 }
 
-func (p *Plugin) executeCommandHelp(args *model.CommandArgs) *model.CommandResponse {
+func (p *Plugin) executeCommandHelp(_ *model.CommandArgs) *model.CommandResponse {
 	return responsef(helpCommandText)
 }
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -30,6 +30,8 @@ func (c *configuration) Clone() *configuration {
 // getConfiguration retrieves the active configuration under lock, making it safe to use
 // concurrently. The active configuration may change underneath the client of this method, but
 // the struct returned by this API call is considered immutable.
+//
+//nolint:unused
 func (p *Plugin) getConfiguration() *configuration {
 	p.configurationLock.RLock()
 	defer p.configurationLock.RUnlock()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -36,7 +36,7 @@ var (
 )
 
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
-func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	switch path := r.URL.Path; path {
@@ -87,7 +87,7 @@ func (p *Plugin) httpMeetingSettings(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (p *Plugin) httpMeetingSaveSettings(w http.ResponseWriter, r *http.Request, mmUserID string) {
+func (p *Plugin) httpMeetingSaveSettings(w http.ResponseWriter, r *http.Request, _ string) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -112,7 +112,7 @@ func (p *Plugin) httpMeetingSaveSettings(w http.ResponseWriter, r *http.Request,
 	p.writeJSON(w, resp)
 }
 
-func (p *Plugin) httpMeetingGetSettings(w http.ResponseWriter, r *http.Request, mmUserID string) {
+func (p *Plugin) httpMeetingGetSettings(w http.ResponseWriter, r *http.Request, _ string) {
 	channelID, ok := r.URL.Query()["channelId"]
 
 	if !ok || len(channelID[0]) < 1 {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -19,7 +19,7 @@ func TestServeHTTP(t *testing.T) {
 	api := &plugintest.API{}
 	plugin.SetAPI(api)
 
-	t.Run("get default meeting settings", func(t *testing.T) {
+	t.Run("get default meeting settings", func(_ *testing.T) {
 		// Mock get default meeting
 		defaultMeeting := &Meeting{
 			ChannelID:     "myChannelId",
@@ -46,7 +46,7 @@ func TestServeHTTP(t *testing.T) {
 		assert.Equal(string(jsonMeeting), string(bodyBytes))
 	})
 
-	t.Run("post meeting settings", func(t *testing.T) {
+	t.Run("post meeting settings", func(_ *testing.T) {
 		// Mock set meeting
 		meeting := &Meeting{
 			ChannelID:     "myChannelId",


### PR DESCRIPTION
closes #113 

- Have resolved any of the unused params flagged by revive (by ignoring with _)

- Have added a nolint rule for the unused getConfiguration function. Didn't feel right to remove it as it has some important logic.